### PR TITLE
fix: capture empty strings

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,7 +5,7 @@ const languages = require('./languages');
 
 const constants = {
   ESCAPED_CHAR_REGEX: /^\\./,
-  QUOTED_STRING_REGEX: /^(['"`])((?:\\\1|[^\1])+?)(\1)/,
+  QUOTED_STRING_REGEX: /^(['"`])((?:\\\1|[^\1])*?)(\1)/,
   NEWLINE_REGEX: /^\r*\n/,
 };
 

--- a/test/JavaScript.js
+++ b/test/JavaScript.js
@@ -142,6 +142,12 @@ describe('JavaScript comments', () => {
     const expected = ['', '', 'someCode();', 'someMoreCode();'].join('\n');
     assert.strictEqual(actual, expected);
   });
+
+  it('should not break on comments that are in between empty strings', () => {
+    const actual = strip('""; // comment \n""');
+    const expected = '""; \n""';
+    assert.strictEqual(actual, expected);
+  });
 });
 
 describe('error handling:', () => {


### PR DESCRIPTION
Previously "" would not be parsed as a string, so
"" // comment ""
would be parsed as the string "\" // comment "
